### PR TITLE
Broken update should still open the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ _testmain.go
 
 # external packages folder
 vendor/
+src/github.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 *Tiny golang app, which can be bundled with your NWJS application (actually, any application) and used for "autoupdates." I really hope that we will have something like this out-of-the box in NWJS!*
 
-### Problem 
+### Problem
 
 NWJS is amazing platform for building desktop applications using web technologies. However, it is missing one important feature - an ability to seamlessly deliver updates for users.
 There were several attempts to solve this problem. For example - https://github.com/edjafarov/node-webkit-updater. But it does have issues when updater itself needs to be updated or NWJS platform needs to be updated (https://github.com/nwjs/nw.js/issues/233).  
@@ -12,18 +12,19 @@ To update target application updater needs to know two things - where zip archiv
 
 ### Build
 
-1) You need to have `golang` installed and properely configured ;)  
-2) Install `glide` https://github.com/Masterminds/glide#install  
-3) Install rsrc `go get github.com/akavel/rsrc`  
-4) Clone this repo  
-5) Go to src/nwjs-autoupdater and edit `nwjs-autoupdater.exe.manifest` as you like. WARNING: don't touch the `requestedExecutionLevel` value.  
-6) Execute `rsrc -manifest nwjs-autoupdater.exe.manifest -ico <path to your icon> -o nwjs-autoupdater.syso` to generate a .syso file with specified resources embedded and to make it WORK ON WINDOWS.
-7) Execute `glide install` to install dependencies  
-8) Go back to the root folder and run `GOPATH=$(pwd) go build nwjs-autoupdater` to build for current platform. To build for other platforms use appropriate flags:  
+1. You need to have `golang` installed and properely configured ;)
+1. Navigate to the root of this repository and run `export GOPATH=$(pwd)`
+1. Install `glide` https://github.com/Masterminds/glide#install
+1. Install rsrc `go get github.com/akavel/rsrc`
+1. Clone this repo
+1. Go to src/nwjs-autoupdater and edit `nwjs-autoupdater.exe.manifest` as you like. WARNING: don't touch the `requestedExecutionLevel` value.
+1. Execute `rsrc -manifest nwjs-autoupdater.exe.manifest -ico <path to your icon> -o nwjs-autoupdater.syso` to generate a .syso file with specified resources embedded and to make it WORK ON WINDOWS.
+1. Execute `glide install` to install dependencies
+1. Go back to the root folder and run `GOPATH=$(pwd) go build nwjs-autoupdater` to build for current platform. To build for other platforms use appropriate flags:
 ```
-    GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o updater 
-    GOOS=windows GOARCH=386 go build -ldflags "-s -w -H=windowsgui" -o updater.exe
-    GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -H=windowsgui" -o updater.exe
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o updater
+GOOS=windows GOARCH=386 go build -ldflags "-s -w -H=windowsgui" -o updater.exe
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -H=windowsgui" -o updater.exe
 ```
 
 > Full list of the platforms and archetectures, which is possible to cross-compile to can be found here https://github.com/golang/go/blob/master/src/go/build/syslist.go
@@ -72,6 +73,6 @@ Because it is simple and more importantly - it can be compiled from any platform
 ### Credits
 I'm not very proficient in the golang (yet) so I've used and slightly modified several packages from the go community (all credits are going to them):
 
-https://github.com/skratchdot/open-golang - Open a file, directory, or URI using the OS's default application for that object type. Optionally, you can specify an application to use.  
-https://github.com/ivaxer/go-xattr - Extended attribute support for Go #golang  
-And very simple zip unpacker (can't find the source)  
+https://github.com/skratchdot/open-golang - Open a file, directory, or URI using the OS's default application for that object type. Optionally, you can specify an application to use.
+https://github.com/ivaxer/go-xattr - Extended attribute support for Go #golang
+And very simple zip unpacker (can't find the source)

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,19 @@
 #!/bin/sh
+export GOPATH=$(pwd)
 rm -rf dist
 mkdir -p dist/darwin/x64
 mkdir -p dist/win32/ia32
 mkdir -p dist/win32/x64
 mkdir -p dist/linux/x64
 cd src/nwjs-autoupdater/
-rsrc -manifest nwjs-autoupdater.exe.manifest -o nwjs-autoupdater.syso
+$GOPATH/bin/rsrc -manifest nwjs-autoupdater.exe.manifest -o nwjs-autoupdater.syso
 glide install
 cd ../../
-GOPATH=$(pwd) GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" nwjs-autoupdater
+GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" nwjs-autoupdater
 mv nwjs-autoupdater dist/linux/x64/autoupdater
-GOPATH=$(pwd) GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" nwjs-autoupdater
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" nwjs-autoupdater
 mv nwjs-autoupdater dist/darwin/x64/autoupdater
-GOPATH=$(pwd) GOOS=windows GOARCH=386 go build -ldflags "-s -w -H=windowsgui" nwjs-autoupdater
+GOOS=windows GOARCH=386 go build -ldflags "-s -w -H=windowsgui" nwjs-autoupdater
 mv nwjs-autoupdater.exe dist/win32/ia32/autoupdater.exe
-GOPATH=$(pwd) GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -H=windowsgui" nwjs-autoupdater
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -H=windowsgui" nwjs-autoupdater
 mv nwjs-autoupdater.exe dist/win32/x64/autoupdater.exe

--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -39,8 +39,7 @@ func main() {
 		wait.WaitProcess(processId, logger)
 	}
 
-	var appExec string;
-	err, appExec = updater.Update(bundle, instDir, appName)
+	err, appExec := updater.Update(bundle, instDir, appName)
 	logger.Print("Finish")
 	if err != nil {
 		logger.Fatal(err)

--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -35,7 +35,7 @@ func main() {
 	logger.Print("appName: ", appName)
 
 	if processId != -1 {
-		logger.Print("Waiting process to exit", processId)
+		logger.Print("Waiting process to exit: ", processId)
 		wait.WaitProcess(processId, logger)
 	}
 

--- a/src/nwjs-autoupdater/main.go
+++ b/src/nwjs-autoupdater/main.go
@@ -40,10 +40,10 @@ func main() {
 	}
 
 	err, appExec := updater.Update(bundle, instDir, appName)
-	logger.Print("Finish")
 	if err != nil {
-		logger.Fatal(err)
+		logger.Print("Updater error: ", 	err)
 	}
+	logger.Print("Finish")
 
 	open.Start(appExec)
 }

--- a/src/nwjs-autoupdater/updater/updater_darwin.go
+++ b/src/nwjs-autoupdater/updater/updater_darwin.go
@@ -23,6 +23,7 @@ func Update(bundle, instDir, appName string) (error, string) {
 
 	err = unzip.Unzip(bundle, tempDir)
 	if err != nil {
+		os.Remove(bundle)
 		return err, appExec
 	}
 

--- a/src/nwjs-autoupdater/updater/updater_darwin.go
+++ b/src/nwjs-autoupdater/updater/updater_darwin.go
@@ -11,50 +11,50 @@ import (
 
 func Update(bundle, instDir, appName string) (error, string) {
 	appExecName := appName + ".app"
-  appExec := filepath.Join(instDir, appExecName)
-  appDir := appExec
-  appBak := appExec + ".bak"
+	appExec := filepath.Join(instDir, appExecName)
+	appDir := appExec
+	appBak := appExec + ".bak"
 
-  tempDir, err := ioutil.TempDir("", appName)
+	tempDir, err := ioutil.TempDir("", appName)
 	if err != nil {
 		return err, appExec
 	}
 	defer os.RemoveAll(tempDir)
 
-  err = unzip.Unzip(bundle, tempDir)
+	err = unzip.Unzip(bundle, tempDir)
 	if err != nil {
 		return err, appExec
 	}
 
-  err = os.Rename(appDir, appBak)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.Rename(appDir, appBak)
+	if err != nil {
+		return err, appExec
+	}
 
-  updateFiles := filepath.Join(tempDir, appExecName)
+	updateFiles := filepath.Join(tempDir, appExecName)
 
-  err = os.Rename(updateFiles, appExec)
-  if err != nil {
-    os.RemoveAll(appExec)
-    os.Rename(appBak, appExec)
+	err = os.Rename(updateFiles, appExec)
+	if err != nil {
+		os.RemoveAll(appExec)
+		os.Rename(appBak, appExec)
 
-    return err, appExec
-  }
+		return err, appExec
+	}
 
-  err = os.RemoveAll(appBak)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.RemoveAll(appBak)
+	if err != nil {
+		return err, appExec
+	}
 
-  err = os.RemoveAll(bundle)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.RemoveAll(bundle)
+	if err != nil {
+		return err, appExec
+	}
 
-  err = xattr.Remove(appExec, "com.apple.quarantine")
-  if err != nil {
-    return err, appExec
-  }
+	err = xattr.Remove(appExec, "com.apple.quarantine")
+	if err != nil {
+		return err, appExec
+	}
 
-  return nil, appExec
+	return nil, appExec
 }

--- a/src/nwjs-autoupdater/updater/updater_linux.go
+++ b/src/nwjs-autoupdater/updater/updater_linux.go
@@ -9,45 +9,45 @@ import (
 
 func Update(bundle, instDir, appName string) (error, string) {
 	appExecName := appName
-  appExec := filepath.Join(instDir, appExecName)
-  appDir := appExec
-  appBak := appExec + ".bak"
+	appExec := filepath.Join(instDir, appExecName)
+	appDir := appExec
+	appBak := appExec + ".bak"
 
-  tempDir, err := ioutil.TempDir("", appName)
+	tempDir, err := ioutil.TempDir("", appName)
 	if err != nil {
 		return err, appExec
 	}
 	defer os.RemoveAll(tempDir)
 
-  err = unzip.Unzip(bundle, tempDir)
+	err = unzip.Unzip(bundle, tempDir)
 	if err != nil {
 		return err, appExec
 	}
 
-  err = os.Rename(appDir, appBak)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.Rename(appDir, appBak)
+	if err != nil {
+		return err, appExec
+	}
 
-  updateFiles := filepath.Join(tempDir, appExecName)
+	updateFiles := filepath.Join(tempDir, appExecName)
 
-  err = os.Rename(updateFiles, appExec)
-  if err != nil {
-    os.RemoveAll(appExec)
-    os.Rename(appBak, appExec)
+	err = os.Rename(updateFiles, appExec)
+	if err != nil {
+		os.RemoveAll(appExec)
+		os.Rename(appBak, appExec)
 
-    return err, appExec
-  }
+		return err, appExec
+	}
 
-  err = os.RemoveAll(appBak)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.RemoveAll(appBak)
+	if err != nil {
+		return err, appExec
+	}
 
-  err = os.RemoveAll(bundle)
-  if err != nil {
-    return err, appExec
-  }
+	err = os.RemoveAll(bundle)
+	if err != nil {
+		return err, appExec
+	}
 
-  return nil, appExec
+	return nil, appExec
 }

--- a/src/nwjs-autoupdater/updater/updater_linux.go
+++ b/src/nwjs-autoupdater/updater/updater_linux.go
@@ -21,6 +21,7 @@ func Update(bundle, instDir, appName string) (error, string) {
 
 	err = unzip.Unzip(bundle, tempDir)
 	if err != nil {
+		os.Remove(bundle)
 		return err, appExec
 	}
 

--- a/src/nwjs-autoupdater/updater/updater_windows.go
+++ b/src/nwjs-autoupdater/updater/updater_windows.go
@@ -8,12 +8,12 @@ import (
 
 func Update(bundle, instDir, appName string) (error, string) {
 	appExecName := appName + ".exe"
-  appExec := filepath.Join(instDir, appExecName)
+	appExec := filepath.Join(instDir, appExecName)
 
-  err := unzip.Unzip(bundle, instDir)
+	err := unzip.Unzip(bundle, instDir)
 	if err != nil {
 		return err, appExec
 	}
 
-  return nil, appExec
+	return nil, appExec
 }

--- a/src/nwjs-autoupdater/updater/updater_windows.go
+++ b/src/nwjs-autoupdater/updater/updater_windows.go
@@ -11,8 +11,8 @@ func Update(bundle, instDir, appName string) (error, string) {
 	appExec := filepath.Join(instDir, appExecName)
 
 	err := unzip.Unzip(bundle, instDir)
+	os.Remove(bundle)
 	if err != nil {
-		os.Remove(bundle)
 		return err, appExec
 	}
 

--- a/src/nwjs-autoupdater/updater/updater_windows.go
+++ b/src/nwjs-autoupdater/updater/updater_windows.go
@@ -2,7 +2,7 @@ package updater
 
 import (
 	"path/filepath"
-
+	"os"
 	"nwjs-autoupdater/unzip"
 )
 
@@ -12,6 +12,7 @@ func Update(bundle, instDir, appName string) (error, string) {
 
 	err := unzip.Unzip(bundle, instDir)
 	if err != nil {
+		os.Remove(bundle)
 		return err, appExec
 	}
 

--- a/src/nwjs-autoupdater/wait/isrunning/isrunning_unix.go
+++ b/src/nwjs-autoupdater/wait/isrunning/isrunning_unix.go
@@ -5,28 +5,24 @@ package isrunning
 import (
 	"os"
 	"syscall"
-	"log"
 )
 
-func IsRunning(pid int, logger *log.Logger) bool {
+func IsRunning(pid int) (bool, string) {
 	// Try to find the process
 	process, err := os.FindProcess(pid)
-	logger.Print("find process: ", pid)
-	logger.Print("process: ", process)
-	logger.Print("err: ", err)
 	if process == nil || err != nil {
-		return false
+		return false, err.Error()
 	}
 	// Send a `0` signal to process and check the response
 	err = process.Signal(syscall.Signal(0))
 	if err == nil {
 		// No errors means process is running
-		return true
+		return true, "Process still running"
 	} else {
 		if err.Error() == "os: process already finished" {
-			return false
+			return false, err.Error()
 		}
 		// Any other error probably means process is still running
-		return true
+		return true, err.Error()
 	}
 }

--- a/src/nwjs-autoupdater/wait/isrunning/isrunning_win.go
+++ b/src/nwjs-autoupdater/wait/isrunning/isrunning_win.go
@@ -4,13 +4,12 @@ package isrunning
 
 import (
 	"os/exec"
-	"log"
 	"strconv"
 	"fmt"
 	"syscall"
 )
 
-func IsRunning(pid int, logger *log.Logger) bool {
+func IsRunning(pid int) (bool, string) {
 	// Convert interger pid to string
 	processId := strconv.Itoa(pid)
 	// Create a query for tasklist
@@ -23,15 +22,16 @@ func IsRunning(pid int, logger *log.Logger) bool {
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	// Get command output
 	cmdOutput, err := cmd.Output()
-	logger.Print("find process:", pid)
-	logger.Print(string(cmdOutput))
-	logger.Print("error: ", err)
+	// If the command returned with error, assume the process is still running
+	if err != nil {
+		return true, err.Error()
+	}
 	// Read 4 first bytes as string
 	result := string(cmdOutput[:4])
 	// If tasklist returns with an "INFO" message it's because no process is
 	// running with that pid
 	if result == "INFO" {
-		return false
+		return false, string(cmdOutput)
 	}
-	return true
+	return true, string(cmdOutput)
 }

--- a/src/nwjs-autoupdater/wait/main.go
+++ b/src/nwjs-autoupdater/wait/main.go
@@ -9,9 +9,11 @@ import (
 func WaitProcess(processId int, logger *log.Logger) {
 	running := true
 	tries := 0
+	var msg string
 	for running && tries < 60 {
-		running = isrunning.IsRunning(processId, logger)
-		logger.Printf("process %s still running: %d\n", processId, running)
+		running, msg = isrunning.IsRunning(processId)
+		logger.Print("Running: ", running)
+		logger.Print("Message: ", msg)
 		if running {
 			time.Sleep(1000 * time.Millisecond)
 			tries += 1


### PR DESCRIPTION
**Problem:**

When the `Update` fails it will exits without reopening the app. In this case if the app (nwjs) is on a state that will always call the `autoupdater` the user get locked out as it gets stuck in the the loop:

1. User opens the app
1. App calls the updater and exits
1. Updater fails and exits without reopening the app

**Solution:**

The updater must **not exit** in case the update fail so the app gets reopened. It should also remove the downloaded bundle to avoid app starting the updater automatically (`restart` procedure).

Note: It still calls `panic` if the updater can't create a log file and in this cases the app won't reopen. 
